### PR TITLE
Fix C compatibility issue in droplist_handle_plot call

### DIFF
--- a/droplist.c
+++ b/droplist.c
@@ -481,7 +481,7 @@ void droplist_plot ()
 	plotdata data;
 
 	droplist_getdata (&data);
-	droplist_handle_plot (&data, NULL, NULL, 0);
+	droplist_handle_plot (&data, 0, NULL, 0);
 	droplist_freedata (&data);
 }
 


### PR DESCRIPTION
The second argument must be an integer, not a pointer.  This is a compilation error with newer compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
